### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -9,3 +9,9 @@
   padding: 20px;
   flex: 1;
 }
+
+@media (max-width: 480px) {
+  .content {
+    padding: 15px 10px;
+  }
+}

--- a/src/components/Navbar.module.css
+++ b/src/components/Navbar.module.css
@@ -49,3 +49,25 @@
 .navbar a.active:hover {
   text-decoration: underline;
 }
+
+@media (max-width: 480px) {
+  .navbar {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .logoContainer {
+    margin-left: 0;
+  }
+
+  .navbar ul {
+    position: static;
+    flex-direction: column;
+    gap: 10px;
+    margin: 10px 0 0;
+  }
+
+  .logo {
+    height: 60px;
+  }
+}

--- a/src/components/Screenshot.module.css
+++ b/src/components/Screenshot.module.css
@@ -5,6 +5,12 @@
   border: none;
 }
 
+@media (max-width: 480px) {
+  .screenshot {
+    max-width: 100%;
+  }
+}
+
 .placeholder {
   background: #f5f3ff;      
   color: #6d28d9;           

--- a/src/pages/Calculator.module.css
+++ b/src/pages/Calculator.module.css
@@ -111,3 +111,26 @@ h1 {
     font-size: 1rem;
   }
 }
+
+@media (max-width: 480px) {
+  .container {
+    padding: 1rem;
+  }
+
+  .screenshot {
+    max-width: 90%;
+  }
+
+  .storeBadge {
+    max-width: 150px;
+  }
+
+  h1 {
+    font-size: 1.5rem;
+  }
+
+  .intro,
+  .cta {
+    font-size: 0.95rem;
+  }
+}

--- a/src/pages/Contact.module.css
+++ b/src/pages/Contact.module.css
@@ -37,3 +37,13 @@ button {
 button:hover {
   background-color: #6b21a8;
 }
+
+@media (max-width: 480px) {
+  .container {
+    padding: 10px;
+  }
+
+  button {
+    width: 100%;
+  }
+}

--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -55,3 +55,17 @@ a {
 a:hover {
   text-decoration: underline;
 }
+
+@media (max-width: 480px) {
+  .container {
+    padding: 0 1rem;
+  }
+
+  li {
+    padding: 12px;
+  }
+
+  h1 {
+    font-size: 1.5rem;
+  }
+}

--- a/src/pages/PrivacyPolicy.module.css
+++ b/src/pages/PrivacyPolicy.module.css
@@ -3,3 +3,9 @@
     max-width: 800px;
     margin: 0 auto;
   }
+
+@media (max-width: 480px) {
+  .container {
+    padding: 15px;
+  }
+}


### PR DESCRIPTION
## Summary
- add mobile layout tweaks for the navbar
- update calculators and pages with small screen media queries
- resize screenshots and badges on phones
- adjust form and policy page padding

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6855db51bbcc8326a36c1902ef6c960f